### PR TITLE
Amélioration de la config privée

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /reports
-/private_features
+/private_features/*.feature
 steps/__pycache__/
 steps/params.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /private_features
 steps/__pycache__/
 steps/params.json
-steps/params.py

--- a/private_features/readme.md
+++ b/private_features/readme.md
@@ -1,0 +1,1 @@
+Mettez dans ce répertoire vos tests sur des données privées.

--- a/private_features/synchro_private_features.py
+++ b/private_features/synchro_private_features.py
@@ -1,0 +1,31 @@
+import shutil
+import os
+import json
+
+# à lancer depuis le repertoire de navitia-checker
+nav_checker_folder = os.path.join(os.getcwd(), "private_features")
+
+params = json.load(open('steps/params.json'))
+datascript_folder = params['navitia-checker']['private_features_repo']
+
+def synchro_to_nav_checker():
+    source = datascript_folder
+    destination = nav_checker_folder
+    synchro(source, destination)
+
+def synchro_from_nav_checker():
+    destination = datascript_folder
+    source = nav_checker_folder
+    synchro(source, destination)
+
+def synchro(source, destination):
+    for a_feature_file in os.listdir(source) :
+        file_name, extension = os.path.splitext(a_feature_file)
+        if extension == ".feature" :
+            destination_file = os.path.join(destination, a_feature_file)
+            source_file = os.path.join(source, a_feature_file)
+            print ("copie du fichier {} de {} vers {}".format(a_feature_file, source_file, destination_file))
+            shutil.copy(source_file, destination_file)
+
+synchro_from_nav_checker()
+# attention, ça "synchronise" en écrasant. Les éventuels conflits sont à régler dans l'autre dépot git.

--- a/readme.md
+++ b/readme.md
@@ -14,17 +14,17 @@ behave -D environnement=prod public_features/fr_idf.feature
 Si vous ne constatez aucune erreur sur les étapes Given, c'est bon !
 
 # Configuration avancée :lock:
-Si, comme nous, vous souhaitez effectuer des tests sur des données non publiques, vous voudrez séparer le répertoire contenant les tests du répertoire contenant le code des tests (celui de navitia-checker).
+Pour effectuer des tests sur des données non publiques, vous pouvez utiliser le répertoire private_features : les tests qui y sont ne sont pas suivis par git.
 
-Nous avons choisi un système de synchronisation de répertoires :
-* le répertoire contenant nos tests est hébergé dans un autre dépôt git, ailleurs
-* un script de synchronisation permet de dupliquer les fichiers features dans le répertoire private_features, afin que navitia-checker les trouve sans efforts
+Afin d'avoir tout de même un suivi git de ces tests (dans un autre dépôt git non public), nous avons choisi un système de synchronisation de répertoires :
+* les tests non publics sont dans le répertoire private_features
+* un script de synchronisation permet de dupliquer les fichiers vers un autre répertoire (associé à un autre dépôt git)
 * une étape (steps) de test est ajoutée pour vérifier que les deux fichiers (source et dupliqué) sont bien identiques
 
 Pour cela :
 * créer votre répertoire de tests privé, où vous voulez
-* dans les tests privés, ajouter l'étape "Given je teste un coverage privé"
 * indiquer le chemin de ce répertoire dans le fichier params.json. C'est un chemin relatif par rapport à la racine du répertoire de navitia-checker
+* dans les tests privés, ajouter l'étape "Given je teste un coverage privé"
 * synchroniser les tests privés de votre autre répertoire avec le répertoire private_features de navitia-checker
 * tester (à la racine du répertoire) :
 ```shell

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,29 @@
 * créer le fichier params.json à partir du fichier default_params.json.
   * Si vous utilisez [navitia-explorer](https://github.com/CanalTP/navitia-explorer), vous pouvez reprendre le même fichier ;)
   * Sinon, obtenez une clef d'authentification navitia.io et mettez là dans le fichier
-* [privé seulement :lock: ] Créer le fichier params.py qui spécifie où se trouvent les sources des tests privés
-* testez (à la racine du repo) :
+* tester (à la racine du répertoire) :
 ```shell
 behave -D environnement=prod public_features/fr_idf.feature
+```
+
+Si vous ne constatez aucune erreur sur les étapes Given, c'est bon !
+
+# Configuration avancée :lock:
+Si, comme nous, vous souhaitez effectuer des tests sur des données non publiques, vous voudrez séparer le répertoire contenant les tests du répertoire contenant le code des tests (celui de navitia-checker).
+
+Nous avons choisi un système de synchronisation de répertoires :
+* le répertoire contenant nos tests est hébergé dans un autre dépôt git, ailleurs
+* un script de synchronisation permet de dupliquer les fichiers features dans le répertoire private_features, afin que navitia-checker les trouve sans efforts
+* une étape (steps) de test est ajoutée pour vérifier que les deux fichiers (source et dupliqué) sont bien identiques
+
+Pour cela :
+* créer votre répertoire de tests privé, où vous voulez
+* dans les tests privés, ajouter l'étape "Given je teste un coverage privé"
+* indiquer le chemin de ce répertoire dans le fichier params.json. C'est un chemin relatif par rapport à la racine du répertoire de navitia-checker
+* synchroniser les tests privés de votre autre répertoire avec le répertoire private_features de navitia-checker
+* tester (à la racine du répertoire) :
+```shell
+behave -D environnement=mine private_features/my_very_own_private_data.feature
 ```
 
 Si vous ne constatez aucune erreur sur les étapes Given, c'est bon !

--- a/steps/basics.py
+++ b/steps/basics.py
@@ -40,15 +40,14 @@ def step_impl(context, test_coverage):
 @given(u'je teste un coverage privé')
 def step_impl(context):
     """
-    Les fichiers features privés sont hébergés dans un autre répertoire et synchronisés avec le répertoire courant.
-    Ce test vérifie qu'ils sont bien synchronisés.
+    Les fichiers features privés sont hébergés dans un autre répertoire et synchronisés (par ailleurs) avec le répertoire courant.
+    Ce test vérifie que les fichiers features sont bien synchronisés.
     """
     destination = os.path.join(os.getcwd(), "private_features")
 
     #récupération de l'adresse du répo privé
-    sys.path.append(os.path.join(os.getcwd(), "steps"))
-    import params as private_data
-    source = private_data.datascript_features_repo
+    params = json.load(open('steps/params.json'))
+    source = params['navitia-checker']['private_features_repo']
 
     nom_fichier_feature = ""
     for an_arg in sys.argv :

--- a/steps/default_params.json
+++ b/steps/default_params.json
@@ -1,12 +1,15 @@
 {
     "environnements": {
-		"api.navitia.io": {
-			"url" : "http://api.navitia.io/v1/",
-			"key" : "get-your-own-api-key-on-navitia.io"
-		},
-		"mine": {
-			"url" : "localhost/navitia/v1",
-			"key" : ""
-		}
-	}
+  		"api.navitia.io": {
+  			"url" : "http://api.navitia.io/v1/",
+  			"key" : "get-your-own-api-key-on-navitia.io"
+  		},
+  		"mine": {
+  			"url" : "localhost/navitia/v1",
+  			"key" : ""
+  		}
+	},
+  "navitia-checker" : {
+    "private_features_repo": "../relative/path/to/my/private/features/folder/from/root/of/navitia-checker/folder"
+  }
 }


### PR DESCRIPTION
* On peut "juste" mettre les tests privés dans le dossier private_features
* Si on veut aller plus loin, on peut faire de la synchro, et ajouter un test sur la bonne synchro

La politique de synchro proposée n'est pas idéale (ça écrase d'un côté ou de l'autre, ça ne synchronise pas vraiment), mais on pourra améliorer ce sujet par ailleurs.

close #3 